### PR TITLE
🐞 fix: 修改背景色绑定逻辑，修复粘贴时的背景色异常

### DIFF
--- a/src/composables/useStyleSync.ts
+++ b/src/composables/useStyleSync.ts
@@ -137,9 +137,17 @@ export function useStyleSync() {
       if (node.type === NodeType.RECT || node.type === NodeType.CIRCLE) {
         return (node as ShapeState).style.backgroundColor || '#ffffff';
       }
-      return '#ffffff';
+      // 对于文本和图片节点，也返回它们的背景色（而不是固定返回白色）
+      return node.style?.backgroundColor || '#ffffff';
     },
-    (node, value) => ({ style: { ...node.style, backgroundColor: value } }),
+    (node, value) => {
+      // 只对矩形和圆形节点应用填充色
+      if (node.type === NodeType.RECT || node.type === NodeType.CIRCLE) {
+        return { style: { ...node.style, backgroundColor: value } };
+      }
+      // 对于其他节点类型，不做任何修改
+      return {};
+    },
     '#ffffff'
   );
 


### PR DESCRIPTION
## 📊 Bug 修复总结
### 🐛 问题描述
复制文本框后粘贴，背景色表现不一致：
- ✅ 在画布空白处右键粘贴 → 背景色正确
- ❌ 在矩形上右键粘贴 → 背景色变成白色且透明度 100%

### 🐛 问题根源

在 useStyleSync.ts 中，`fillColor` 计算属性的设计有问题：

**旧逻辑：**
```typescript
const fillColor = createBinding<string>(
  (node) => {
    if (node.type === NodeType.RECT || node.type === NodeType.CIRCLE) {
      return node.style.backgroundColor || '#ffffff';
    }
    return '#ffffff';  // ❌ 文本框总是返回白色
  },
  (node, value) => ({ style: { ...node.style, backgroundColor: value } }),  // ❌ 对所有节点类型都应用
  '#ffffff'
);
```

当选中状态从矩形切换到文本框时：
1. `fillColor.get()` 被调用，因为文本框不是矩形/圆形，返回 `#ffffff`
2. Vue 响应式系统检测到值变化
3. `fillColor.set('#ffffff')` 被触发
4. 调用 `updateNode`，将文本框的背景色改成了白色

### ✅ 修复方案

```typescript
const fillColor = createBinding<string>(
  (node) => {
    if (node.type === NodeType.RECT || node.type === NodeType.CIRCLE) {
      return node.style.backgroundColor || '#ffffff';
    }
    // ✅ 对于文本框，返回其原本的背景色
    return node.style?.backgroundColor || '#ffffff';
  },
  (node, value) => {
    // ✅ 只对矩形和圆形应用填充色
    if (node.type === NodeType.RECT || node.type === NodeType.CIRCLE) {
      return { style: { ...node.style, backgroundColor: value } };
    }
    // ✅ 对于其他节点类型，不做任何修改
    return {};
  },
  '#ffffff'
);
```

现在 `fillColor` 只会修改矩形和圆形的背景色，不会影响文本框的背景色，