### PR TITLE
feat:优化 旋转手柄与选框间距

### DIFF
--- a/src/components/canvas/SelectionOverlay.vue
+++ b/src/components/canvas/SelectionOverlay.vue
@@ -547,6 +547,8 @@ const onHandleDown = (e: MouseEvent, handle: ResizeHandle) => {
   }
 };
 
+const ROTATE_HANDLE_OFFSET = 32; // 旋转手柄与选框的固定像素间距（缩放后保持视觉距离）
+
 // 旋转样式计算
 const rotateHandleStyle = computed(() => {
   const bounds = operationBounds.value;
@@ -560,12 +562,16 @@ const rotateHandleStyle = computed(() => {
       ? selectedNodes.value[0].transform.rotation
       : 0;
 
-  const quarterHeight = bounds.height / 4;
+  // 仅在非交互态下，根据旋转角度调节手柄间距（旋转结束后再判断，避免交互跳动）
+  const normalizedRotation = ((rotation % 360) + 360) % 360;
+  const isHandleNearTop =
+    !store.isInteracting && normalizedRotation > 140 && normalizedRotation < 220;
+  const offset = ROTATE_HANDLE_OFFSET * (isHandleNearTop ? 3 : 1);
 
   return {
     // 旋转 handle 元素本身，使其图标始终正向朝上
     transform: `translateX(-50%) rotate(${-rotation}deg) scale(${scale})`,
-    bottom: `${-1.5 * quarterHeight}px`,
+    bottom: `${-offset * scale}px`,
     left: '50%',
   };
 });


### PR DESCRIPTION


当旋转角度落在 140°~220°（手柄朝上方）且已停止交互时，自动将间距加2倍以避免顶端遮挡；其余状态保持原 32px 间距

![PixPin_2025-12-10_01-26-57](https://github.com/user-attachments/assets/e90bfe19-d35d-403c-ab54-a1fa96a9bcae)
